### PR TITLE
Update classifiers.py

### DIFF
--- a/core/classifiers.py
+++ b/core/classifiers.py
@@ -214,8 +214,8 @@ class BERTSubclassPredictor(metaclass=Singleton):
             self._load_in_memory()
 
         x = self._to_feature_vector(text)
-        y = self.model.predict_step(x)
-
+        y = self.model.predict(x)[0]
+        
         # sort subclasses in descending order of relevancy
         subclasses = [self.subclass_codes[i] for i in np.argsort(y)[::-1]]
 

--- a/core/classifiers.py
+++ b/core/classifiers.py
@@ -214,7 +214,7 @@ class BERTSubclassPredictor(metaclass=Singleton):
             self._load_in_memory()
 
         x = self._to_feature_vector(text)
-        y = self.model.predict_step(x)[0]
+        y = self.model.predict_step(x)
 
         # sort subclasses in descending order of relevancy
         subclasses = [self.subclass_codes[i] for i in np.argsort(y)[::-1]]


### PR DESCRIPTION
predict_step() is not handling the list of inputs correctly. BERT models need both token IDs and segment IDs (the two inputs you're preparing).
To unpack it properly i did

y = self.model.predict(x)[0]

model.predict() is the standard Keras method that properly handles multiple inputs. The predict_step() method wrapping inputs incorrectly in your case.
